### PR TITLE
remove xtra 'h' from cdn url; fix cf/cdn logo sizes

### DIFF
--- a/events/2016/austin.html
+++ b/events/2016/austin.html
@@ -80,15 +80,15 @@
         <a href="https://capitalfactory.com/">
           <div class="sponsor">
             <h2>Venue Sponsor</h2>
-            <img src="/images/capitalfactory-logo.jpg" alt="CapitalFactory" style="max-width: 300px"/>
+            <img src="/images/capitalfactory-logo.jpg" alt="CapitalFactory" style="width:250px;"/>
           </div>
         </a>
       </div>
       <div class="container center-text">
-        <a href="hhttp://collaborare.net">
+        <a href="http://collaborare.net">
           <div class="sponsor">
             <h2>Breakfast Sponsor</h2>
-            <img src="/images/collaborare-logo.png" alt="Collaborare" style="max-width: 300px"/>
+            <img src="/images/collaborare-logo.png" alt="Collaborare" style="width:200px; height:173px;"/>
             <h3>Collaborare Dot Net, LLC</h3>
           </div>
         </a>


### PR DESCRIPTION
Hi, y'all just a couple of fixes. 

* there was an [extra 'h' in the anchor url](https://github.com/NodeTogether/nodetogether.org/blob/gh-pages/events/2016/austin.html#L88) for Collaborare Dot Net
* the sizes of the logos seemed a little big for Collaborare Dot Net and Capital Factory.  Fixed in explicit styling in lieu of CSS, given ephemeral use of page.

Thanks!  

--Monico